### PR TITLE
Chore/dont modify frozen hash

### DIFF
--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -3,7 +3,8 @@ module Crummy
   class StandardRenderer
     include ActionView::Helpers::UrlHelper
     include ActionView::Helpers::TagHelper unless self.included_modules.include?(ActionView::Helpers::TagHelper)
-    ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.merge([:itemscope].to_set)
+    ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES =
+      ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.dup.merge([:itemscope].to_set).freeze
 
     # Render the list of crumbs as either html or xml
     #

--- a/lib/crummy/standard_renderer.rb
+++ b/lib/crummy/standard_renderer.rb
@@ -3,8 +3,11 @@ module Crummy
   class StandardRenderer
     include ActionView::Helpers::UrlHelper
     include ActionView::Helpers::TagHelper unless self.included_modules.include?(ActionView::Helpers::TagHelper)
-    ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES =
-      ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.dup.merge([:itemscope].to_set).freeze
+
+    Kernel::silence_warnings do
+      ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES =
+        ActionView::Helpers::TagHelper::BOOLEAN_ATTRIBUTES.dup.merge([:itemscope].to_set).freeze
+    end
 
     # Render the list of crumbs as either html or xml
     #

--- a/lib/crummy/version.rb
+++ b/lib/crummy/version.rb
@@ -1,6 +1,6 @@
 module Crummy
   MAJOR = 1
   MINOR = 9
-  PATCH  = 0
+  PATCH  = 1
   VERSION = [MAJOR, MINOR, PATCH].join('.')
 end


### PR DESCRIPTION
Notes
===

[This commit in Rails@master](https://github.com/rails/rails/commit/25ed6627ddac95a95f1d58d3202518544cebdd35) breaks Crummy. I'm fixing it in preparation for the upgrade.